### PR TITLE
PLUGIN-1107-dlp-plugins-should-support-a-dlp-location

### DIFF
--- a/docs/SensitiveRecordDecrypt-transform.md
+++ b/docs/SensitiveRecordDecrypt-transform.md
@@ -14,7 +14,7 @@ granted through the service account that is provided in the plugin configuration
 
 The `DLP Administrator` role must be granted to the service account to allow this plugin to access the DLP APIs.
 
-While using `Deterministic Encryption` with `KMS Wrapped Key`, `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
+While using `Deterministic Encryption` with `KMS Wrapped Key`, the `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
 
 Description
 -----------

--- a/docs/SensitiveRecordDecrypt-transform.md
+++ b/docs/SensitiveRecordDecrypt-transform.md
@@ -14,6 +14,8 @@ granted through the service account that is provided in the plugin configuration
 
 The `DLP Administrator` role must be granted to the service account to allow this plugin to access the DLP APIs.
 
+While using `Deterministic Encryption` with `KMS Wrapped Key`, `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
+
 Description
 -----------
 This plugin decrypts sensitive data that was encrypted by DLP using a reversible encryption transform, such as `Format 

--- a/docs/SensitiveRecordRedaction-transform.md
+++ b/docs/SensitiveRecordRedaction-transform.md
@@ -14,7 +14,7 @@ granted through the service account that is provided in the plugin configuration
 
 The `DLP Administrator` role must be granted to the service account to allow this plugin to access the DLP APIs.
 
-While using `Deterministic Encryption` with `KMS Wrapped Key`, `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
+While using `Deterministic Encryption` with `KMS Wrapped Key`, the `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
 
 Description
 -----------

--- a/docs/SensitiveRecordRedaction-transform.md
+++ b/docs/SensitiveRecordRedaction-transform.md
@@ -14,6 +14,8 @@ granted through the service account that is provided in the plugin configuration
 
 The `DLP Administrator` role must be granted to the service account to allow this plugin to access the DLP APIs.
 
+While using `Deterministic Encryption` with `KMS Wrapped Key`, `Cloud KMS CryptoKey Encrypter/Decrypter` role must be granted to `Cloud Data Loss Prevention Service Agent`
+
 Description
 -----------
 This plugin transforms sensitive records from the input stream. A record is 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>dlp</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>Data Loss Prevention Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Data Loss Prevention</description>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>dlp</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <name>Data Loss Prevention Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for Data Loss Prevention</description>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,12 @@
       <version>0.23.0</version>
       <scope>compile</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.cloud/google-cloud-kms -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-kms</artifactId>
+      <version>2.4.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -70,14 +70,14 @@
   </distributionManagement>
 
   <properties>
-    <dlp.version>0.111.0-beta</dlp.version>
+    <dlp.version>3.1.4</dlp.version>
     <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <avro.version>1.8.2</avro.version>
     <commons.codec.version>1.4</commons.codec.version>
     <cdap.version>6.7.0-SNAPSHOT</cdap.version>
     <cdap.plugin.version>2.9.0-SNAPSHOT</cdap.plugin.version>
-    <google.protobuf.java.version>3.4.0</google.protobuf.java.version>
+    <google.protobuf.java.version>3.19.4</google.protobuf.java.version>
     <guava.version>27.0.1-jre</guava.version>
     <httpclient.version>4.5.6</httpclient.version>
     <jackson.core.version>2.9.10.1</jackson.core.version>
@@ -245,6 +245,48 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http -->
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.5.3</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.cloud/google-cloud-core -->
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <version>2.5.6</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.grpc/grpc-netty-shaded -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty-shaded</artifactId>
+      <version>1.44.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.opencensus/opencensus-api -->
+    <dependency>
+      <groupId>io.opencensus</groupId>
+      <artifactId>opencensus-api</artifactId>
+      <version>0.31.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.grpc/grpc-auth -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-auth</artifactId>
+      <version>1.44.1</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/io.perfmark/perfmark-api -->
+    <dependency>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-api</artifactId>
+      <version>0.23.0</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.dlp.configs.DlpFieldTransformationConfig;
@@ -45,6 +46,7 @@ public class DLPTransformPluginConfig extends GCPConfig {
   public static final String CUSTOM_TEMPLATE_PATH_NAME = "customTemplatePath";
   public static final String TEMPLATE_ID_NAME = "templateId";
   public static final String CUSTOM_TEMPLATE_ENABLED_NAME = "customTemplateEnabled";
+  public static final String DLP_LOCATION = "dlpLocation";
   @Macro
   protected String fieldsToTransform;
 
@@ -61,6 +63,12 @@ public class DLPTransformPluginConfig extends GCPConfig {
   @Macro
   @Nullable
   protected String customTemplatePath;
+
+  @Name(DLP_LOCATION)
+  @Description("DLP Location")
+  @Macro
+  @Nullable
+  protected String dlpLocation;
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(DlpFieldTransformationConfig.class, new DlpFieldTransformationConfigCodec())
@@ -185,5 +193,9 @@ public class DLPTransformPluginConfig extends GCPConfig {
           .withConfigProperty(FIELDS_TO_TRANSFORM);
       }
     }
+  }
+
+  public String getDlpLocation() {
+    return dlpLocation;
   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.dlp;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.privacy.dlp.v2.LocationName;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -200,11 +201,14 @@ public class DLPTransformPluginConfig extends GCPConfig {
     return dlpLocation;
   }
 
-  public String getDlpParentResourceLocation() {
-    String parent = "projects/" + getProject();
-    if (!Strings.isNullOrEmpty(getDlpLocation())) {
-      parent += "/locations/" + getDlpLocation();
+  public String getDlpParentResourceLocationUtil(String project, String location) {
+    if (Strings.isNullOrEmpty(location)) {
+      location = "global";
     }
-    return parent;
+    return LocationName.format(project, location);
+  }
+
+  public String getDlpParentResourceLocation() {
+    return getDlpParentResourceLocationUtil(getProject(), getDlpLocation());
   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -65,8 +65,8 @@ public class DLPTransformPluginConfig extends GCPConfig {
   protected String customTemplatePath;
 
   @Name(DLP_LOCATION)
-  @Description("Resource location of DLP Service (if KMS Wrapped Key is used, should be set to the same location"
-      + " as KMS Resource location)")
+  @Description("Resource location of DLP Service "
+      + "(for more info: https://cloud.google.com/dlp/docs/specifying-location)")
   @Macro
   @Nullable
   protected String dlpLocation;
@@ -119,11 +119,6 @@ public class DLPTransformPluginConfig extends GCPConfig {
                              "Must specify only one of template id or template path")
           .withConfigProperty(TEMPLATE_ID_NAME).withConfigProperty(CUSTOM_TEMPLATE_PATH_NAME);
       }
-    }
-
-    if (Strings.isNullOrEmpty(dlpLocation)) {
-      collector.addFailure("Resource Location is not specified.", "Must specify Resource Location.")
-          .withConfigProperty(DLP_LOCATION);
     }
 
     if (fieldsToTransform != null) {
@@ -203,5 +198,13 @@ public class DLPTransformPluginConfig extends GCPConfig {
 
   public String getDlpLocation() {
     return dlpLocation;
+  }
+
+  public String getDlpParentResourceLocation() {
+    String parent = "projects/" + getProject();
+    if (!Strings.isNullOrEmpty(getDlpLocation())) {
+      parent += "/locations/" + getDlpLocation();
+    }
+    return parent;
   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.dlp.configs.DlpFieldTransformationConfig;
@@ -45,6 +46,7 @@ public class DLPTransformPluginConfig extends GCPConfig {
   public static final String CUSTOM_TEMPLATE_PATH_NAME = "customTemplatePath";
   public static final String TEMPLATE_ID_NAME = "templateId";
   public static final String CUSTOM_TEMPLATE_ENABLED_NAME = "customTemplateEnabled";
+  public static final String DLP_LOCATION = "dlpLocation";
   @Macro
   protected String fieldsToTransform;
 
@@ -61,6 +63,13 @@ public class DLPTransformPluginConfig extends GCPConfig {
   @Macro
   @Nullable
   protected String customTemplatePath;
+
+  @Name(DLP_LOCATION)
+  @Description("Resource location of DLP Service (if KMS Wrapped Key is used, should be set to the same location"
+      + " as KMS Resource location)")
+  @Macro
+  @Nullable
+  protected String dlpLocation;
 
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(DlpFieldTransformationConfig.class, new DlpFieldTransformationConfigCodec())
@@ -110,6 +119,11 @@ public class DLPTransformPluginConfig extends GCPConfig {
                              "Must specify only one of template id or template path")
           .withConfigProperty(TEMPLATE_ID_NAME).withConfigProperty(CUSTOM_TEMPLATE_PATH_NAME);
       }
+    }
+
+    if (Strings.isNullOrEmpty(dlpLocation)) {
+      collector.addFailure("Resource Location is not specified.", "Must specify Resource Location.")
+          .withConfigProperty(DLP_LOCATION);
     }
 
     if (fieldsToTransform != null) {
@@ -185,5 +199,9 @@ public class DLPTransformPluginConfig extends GCPConfig {
           .withConfigProperty(FIELDS_TO_TRANSFORM);
       }
     }
+  }
+
+  public String getDlpLocation() {
+    return dlpLocation;
   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -201,14 +201,14 @@ public class DLPTransformPluginConfig extends GCPConfig {
     return dlpLocation;
   }
 
-  public String getDlpParentResourceLocationUtil(String project, String location) {
+  public LocationName getDlpParentResourceLocationUtil(String project, String location) {
     if (Strings.isNullOrEmpty(location)) {
       location = "global";
     }
-    return LocationName.format(project, location);
+    return LocationName.of(project, location);
   }
 
-  public String getDlpParentResourceLocation() {
+  public LocationName getDlpParentResourceLocation() {
     return getDlpParentResourceLocationUtil(getProject(), getDlpLocation());
   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/DLPTransformPluginConfig.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -141,7 +142,7 @@ public class DLPTransformPluginConfig extends GCPConfig {
 
   private void validateFieldConfigs(List<DlpFieldTransformationConfig> configs,
                                     FailureCollector collector, Schema inputSchema) {
-    HashMap<String, String> transforms = new HashMap<>();
+    Map<String, String> transforms = new HashMap<>();
     Boolean firstTransformUsedCustomTemplate = null;
     Boolean anyTransformUsedCustomTemplate = false;
     for (DlpFieldTransformationConfig config : configs) {
@@ -162,39 +163,36 @@ public class DLPTransformPluginConfig extends GCPConfig {
       anyTransformUsedCustomTemplate = anyTransformUsedCustomTemplate || filters.contains("NONE");
       if (firstTransformUsedCustomTemplate == null) {
         firstTransformUsedCustomTemplate = filters.contains("NONE");
-      } else {
-        if (filters.contains("NONE") != firstTransformUsedCustomTemplate) {
-          errorConfig.setTransformPropertyId("filters");
-          collector.addFailure("Cannot use custom templates and built-in filters in the same plugin instance.",
-                               "All transforms must use custom templates or built-in filters, not a "
-                                 + "combination of both.")
+      } else if (filters.contains("NONE") != firstTransformUsedCustomTemplate) {
+        errorConfig.setTransformPropertyId("filters");
+        collector.addFailure("Cannot use custom templates and built-in filters in the same plugin instance.",
+                             "All transforms must use custom templates or built-in filters, not a "
+                               + "combination of both.")
             .withConfigElement(FIELDS_TO_TRANSFORM, GSON.toJson(errorConfig));
-        }
       }
 
       // Make sure the combination of field, transform and filter are unique
       for (String field : config.getFields()) {
         for (String filter : config.getFilterDisplayNames()) {
           String transformKey = String.format("%s:%s", field, filter);
-          if (transforms.containsKey(transformKey)) {
-
-            String errorMessage;
-            if (transforms.get(transformKey).equalsIgnoreCase(config.getTransform())) {
-              errorMessage = String.format(
-                "Combination of transform, filter and field must be unique. Found multiple definitions for '%s' "
-                  + "transform on '%s' with filter '%s'", config.getTransform(), field, filter);
-            } else {
-              errorMessage = String.format(
-                "Only one transform can be defined per field and filter combination. Found conflicting transforms"
-                  + " '%s' and '%s'",
-                transforms.get(transformKey), config.getTransform());
-            }
-            errorConfig.setTransformPropertyId("");
-            collector.addFailure(errorMessage, "")
-              .withConfigElement(FIELDS_TO_TRANSFORM, GSON.toJson(errorConfig));
-          } else {
+          if (!transforms.containsKey(transformKey)) {
             transforms.put(transformKey, config.getTransform());
+            continue;
           }
+          String errorMessage;
+          if (transforms.get(transformKey).equalsIgnoreCase(config.getTransform())) {
+            errorMessage = String.format(
+              "Combination of transform, filter and field must be unique. Found multiple definitions for '%s' "
+                + "transform on '%s' with filter '%s'", config.getTransform(), field, filter);
+          } else {
+            errorMessage = String.format(
+              "Only one transform can be defined per field and filter combination. Found conflicting transforms"
+                + " '%s' and '%s'",
+                transforms.get(transformKey), config.getTransform());
+          }
+          errorConfig.setTransformPropertyId("");
+          collector.addFailure(errorMessage, "")
+            .withConfigElement(FIELDS_TO_TRANSFORM, GSON.toJson(errorConfig));
         }
       }
 
@@ -228,20 +226,15 @@ public class DLPTransformPluginConfig extends GCPConfig {
     }
   }
 
-  @Nullable
   public String getLocation() {
+    if (Strings.isNullOrEmpty(location)) {
+      return "global";
+    }
     return location;
   }
 
-  public LocationName getLocationNameUtil(String project, @Nullable String location) {
-    if (Strings.isNullOrEmpty(location)) {
-      location = "global";
-    }
-    return LocationName.of(project, location);
-  }
-
   public LocationName getLocationName() {
-    return getLocationNameUtil(getProject(), getLocation());
+    return LocationName.of(getProject(), getLocation());
   }
 
 

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
@@ -155,8 +155,7 @@ public class SensitiveRecordDecrypt extends Transform<StructuredRecord, Structur
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     ReidentifyContentRequest.Builder requestBuilder = ReidentifyContentRequest.newBuilder()
-      .setParent(
-        "projects/" + config.getProject() + "/locations/" + config.getDlpLocation())
+      .setParent(config.getDlpParentResourceLocation())
       .setReidentifyConfig(deidentifyConfig)
       .setItem(item);
 

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
@@ -156,7 +156,7 @@ public class SensitiveRecordDecrypt extends Transform<StructuredRecord, Structur
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     ReidentifyContentRequest.Builder requestBuilder = ReidentifyContentRequest.newBuilder()
       .setParent(
-        "projects/" + config.getProject())
+        "projects/" + config.getProject() + "/locations/" + config.getDlpLocation())
       .setReidentifyConfig(deidentifyConfig)
       .setItem(item);
 

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
@@ -155,7 +155,7 @@ public class SensitiveRecordDecrypt extends Transform<StructuredRecord, Structur
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     ReidentifyContentRequest.Builder requestBuilder = ReidentifyContentRequest.newBuilder()
-      .setParent(config.getDlpParentResourceLocation().toString())
+      .setParent(config.getLocationName().toString())
       .setReidentifyConfig(deidentifyConfig)
       .setItem(item);
 

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordDecrypt.java
@@ -155,7 +155,7 @@ public class SensitiveRecordDecrypt extends Transform<StructuredRecord, Structur
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     ReidentifyContentRequest.Builder requestBuilder = ReidentifyContentRequest.newBuilder()
-      .setParent(config.getDlpParentResourceLocation())
+      .setParent(config.getDlpParentResourceLocation().toString())
       .setReidentifyConfig(deidentifyConfig)
       .setItem(item);
 

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
@@ -21,8 +21,6 @@ import com.google.api.gax.rpc.ResourceExhaustedException;
 import com.google.cloud.dlp.v2.DlpServiceClient;
 import com.google.cloud.dlp.v2.DlpServiceSettings;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.privacy.dlp.v2.ContentItem;
 import com.google.privacy.dlp.v2.DeidentifyConfig;
 import com.google.privacy.dlp.v2.DeidentifyContentRequest;

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
@@ -156,8 +156,7 @@ public class SensitiveRecordRedaction extends Transform<StructuredRecord, Struct
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     DeidentifyContentRequest.Builder requestBuilder = DeidentifyContentRequest.newBuilder()
-      .setParent(
-        "projects/" + config.getProject() + "/locations/" + config.getDlpLocation())
+      .setParent(config.getDlpParentResourceLocation())
       .setDeidentifyConfig(deidentifyConfig)
       .setItem(item);
     if (config.customTemplateEnabled) {

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
@@ -154,7 +154,7 @@ public class SensitiveRecordRedaction extends Transform<StructuredRecord, Struct
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     DeidentifyContentRequest.Builder requestBuilder = DeidentifyContentRequest.newBuilder()
-      .setParent(config.getDlpParentResourceLocation().toString())
+      .setParent(config.getLocationName().toString())
       .setDeidentifyConfig(deidentifyConfig)
       .setItem(item);
     if (config.customTemplateEnabled) {

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
@@ -157,7 +157,7 @@ public class SensitiveRecordRedaction extends Transform<StructuredRecord, Struct
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     DeidentifyContentRequest.Builder requestBuilder = DeidentifyContentRequest.newBuilder()
       .setParent(
-        "projects/" + config.getProject())
+        "projects/" + config.getProject() + "/locations/" + config.getDlpLocation())
       .setDeidentifyConfig(deidentifyConfig)
       .setItem(item);
     if (config.customTemplateEnabled) {

--- a/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
+++ b/src/main/java/io/cdap/plugin/dlp/SensitiveRecordRedaction.java
@@ -154,7 +154,7 @@ public class SensitiveRecordRedaction extends Transform<StructuredRecord, Struct
 
     ContentItem item = ContentItem.newBuilder().setTable(dlpTable).build();
     DeidentifyContentRequest.Builder requestBuilder = DeidentifyContentRequest.newBuilder()
-      .setParent(config.getDlpParentResourceLocation())
+      .setParent(config.getDlpParentResourceLocation().toString())
       .setDeidentifyConfig(deidentifyConfig)
       .setItem(item);
     if (config.customTemplateEnabled) {

--- a/src/main/java/io/cdap/plugin/dlp/configs/CryptoDeterministicTransformationConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/configs/CryptoDeterministicTransformationConfig.java
@@ -88,4 +88,12 @@ public class CryptoDeterministicTransformationConfig implements DlpTransformConf
   public List<Schema.Type> getSupportedTypes() {
     return Arrays.asList(supportedTypes);
   }
+
+  public CryptoKeyHelper.KeyType getKeyType() {
+    return keyType;
+  }
+
+  public String getCryptoKeyName() {
+    return cryptoKeyName;
+  }
 }

--- a/src/main/java/io/cdap/plugin/dlp/configs/CryptoHashTransformationConfig.java
+++ b/src/main/java/io/cdap/plugin/dlp/configs/CryptoHashTransformationConfig.java
@@ -22,6 +22,7 @@ import com.google.privacy.dlp.v2.PrimitiveTransformation;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 
+import io.cdap.plugin.dlp.configs.CryptoKeyHelper.KeyType;
 import java.util.Arrays;
 import java.util.List;
 
@@ -59,4 +60,12 @@ public class CryptoHashTransformationConfig implements DlpTransformConfig {
   public List<Schema.Type> getSupportedTypes() {
     return Arrays.asList(supportedTypes);
   }
+
+  public String getCryptoKeyName() {
+    return cryptoKeyName;
+  }
+
+   public KeyType getKeyType() {
+    return keyType;
+   }
 }

--- a/src/main/java/io/cdap/plugin/dlp/configs/CryptoKeyHelper.java
+++ b/src/main/java/io/cdap/plugin/dlp/configs/CryptoKeyHelper.java
@@ -16,6 +16,8 @@
 
 package io.cdap.plugin.dlp.configs;
 
+import com.google.api.pathtemplate.ValidationException;
+import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import com.google.gson.Gson;
@@ -29,6 +31,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.Random;
+import javax.annotation.Nullable;
 
 
 /**
@@ -127,6 +130,34 @@ public class CryptoKeyHelper {
             .withConfigElement(widgetName, gson.toJson(errorConfig));
         }
         break;
+    }
+  }
+
+  public static CryptoKeyName getCmekKey(@Nullable String cmekKey, FailureCollector collector, String widgetName) {
+    CryptoKeyName cmekKeyName = null;
+    if (Strings.isNullOrEmpty(cmekKey)) {
+      return cmekKeyName;
+    }
+    try {
+      cmekKeyName = CryptoKeyName.parse(cmekKey);
+    } catch (ValidationException e) {
+      collector.addFailure(e.getMessage(), null)
+        .withConfigProperty(widgetName).withStacktrace(e.getStackTrace());
+    }
+    return cmekKeyName;
+  }
+
+  public static void validateCryptoKeyNameLocation(String location, String cryptoKeyName, FailureCollector collector,
+                                                   String cryptoKeyNameWidgetName, String locationWidgetName) {
+    CryptoKeyName key = CryptoKeyHelper.getCmekKey(cryptoKeyName, collector, cryptoKeyNameWidgetName);
+    if (key != null) {
+      String keyLocation = key.getLocation();
+      String dlpLocation = Strings.isNullOrEmpty(location) ? "global" : location;
+      if (!keyLocation.equalsIgnoreCase(dlpLocation)) {
+        collector.addFailure("Location of DLP service and wrappedKey are not same.",
+                "DLP Resource location and wrappedKey location must be same.")
+          .withConfigProperty(locationWidgetName);
+      }
     }
   }
 }

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -1,6 +1,7 @@
 package io.cdap.plugin.dlp;
 
 import com.google.privacy.dlp.v2.FieldId;
+import com.google.privacy.dlp.v2.LocationName;
 import com.google.privacy.dlp.v2.Table;
 import com.google.privacy.dlp.v2.Value;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -11,6 +12,7 @@ import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import java.lang.reflect.Field;
 
 import java.time.LocalDate;
 
@@ -113,31 +115,29 @@ public class UtilsTest {
   }
 
   @Test
-  public void testDlpLocation() {
-    //DLPTransformPluginConfig is initialized with 'null' projectId
-    //if this logic is changed, this test case is going to fail
+  public void testDlpLocation() throws NoSuchFieldException, IllegalAccessException {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    config.customTemplateEnabled = false;
-    config.dlpLocation = "europe-west1";
-    Assert.assertEquals("projects/null/locations/europe-west1", config.getDlpParentResourceLocation());
+    String project = "test_project";
+    String location = "europe-west1";
+    Assert.assertEquals("projects/test_project/locations/europe-west1",
+        config.getDlpParentResourceLocationUtil(project, location));
   }
 
   @Test
   public void testNullDlpLocation() {
-    //DLPTransformPluginConfig is initialized with 'null' projectId
-    //if this logic is changed, this test case is going to fail
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    config.customTemplateEnabled = false;
-    Assert.assertEquals("projects/null", config.getDlpParentResourceLocation());
+    String project = "test_project";
+    String location = "";
+    Assert.assertEquals("projects/test_project/locations/global",
+        config.getDlpParentResourceLocationUtil(project, location));
   }
 
   @Test
   public void testEmptyDlpLocation() {
-    //DLPTransformPluginConfig is initialized with 'null' projectId
-    //if this logic is changed, this test case is going to fail
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    config.customTemplateEnabled = false;
-    config.dlpLocation = "";
-    Assert.assertEquals("projects/null", config.getDlpParentResourceLocation());
+    String project = "test_project";
+    String location = null;
+    Assert.assertEquals("projects/test_project/locations/global",
+        config.getDlpParentResourceLocationUtil(project, location));
   }
 }

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -164,7 +164,7 @@ public class UtilsTest {
     String project = "test_project";
     String location = "europe-west1";
     Assert.assertEquals("projects/test_project/locations/europe-west1",
-      config.getDlpParentResourceLocationUtil(project, location).toString());
+      config.getLocationNameUtil(project, location).toString());
   }
 
   @Test
@@ -173,7 +173,7 @@ public class UtilsTest {
     String project = "test_project";
     String location = "";
     Assert.assertEquals("projects/test_project/locations/global",
-      config.getDlpParentResourceLocationUtil(project, location).toString());
+      config.getLocationNameUtil(project, location).toString());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class UtilsTest {
     String project = "test_project";
     String location = null;
     Assert.assertEquals("projects/test_project/locations/global",
-      config.getDlpParentResourceLocationUtil(project, location).toString());
+      config.getLocationNameUtil(project, location).toString());
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -120,7 +120,7 @@ public class UtilsTest {
     String project = "test_project";
     String location = "europe-west1";
     Assert.assertEquals("projects/test_project/locations/europe-west1",
-        config.getDlpParentResourceLocationUtil(project, location));
+        config.getDlpParentResourceLocationUtil(project, location).toString());
   }
 
   @Test
@@ -129,7 +129,7 @@ public class UtilsTest {
     String project = "test_project";
     String location = "";
     Assert.assertEquals("projects/test_project/locations/global",
-        config.getDlpParentResourceLocationUtil(project, location));
+        config.getDlpParentResourceLocationUtil(project, location).toString());
   }
 
   @Test
@@ -138,6 +138,6 @@ public class UtilsTest {
     String project = "test_project";
     String location = null;
     Assert.assertEquals("projects/test_project/locations/global",
-        config.getDlpParentResourceLocationUtil(project, location));
+        config.getDlpParentResourceLocationUtil(project, location).toString());
   }
 }

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -73,6 +73,7 @@ public class UtilsTest {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = true;
     config.templateId = null;
+    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("customTemplateEnabledAndEmpty");
     config.validate(collector, null);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -89,6 +90,7 @@ public class UtilsTest {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = true;
     config.customTemplatePath = "simple_template";
+    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("customTemplateEnabled");
     config.validate(collector, null);
     Assert.assertEquals(0, collector.getValidationFailures().size());
@@ -100,6 +102,7 @@ public class UtilsTest {
     config.customTemplateEnabled = true;
     config.templateId = "template";
     config.customTemplatePath = "anotherTemplate";
+    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("BothCustomTemplateEnabled");
     config.validate(collector, null);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -110,5 +113,32 @@ public class UtilsTest {
     Assert.assertEquals("Both template id and template path are specified.",
                         collector.getValidationFailures().get(0).getMessage());
 
+  }
+
+  @Test
+  public void testEmptyDlpLocation() {
+    DLPTransformPluginConfig config = new DLPTransformPluginConfig();
+    config.customTemplateEnabled = false;
+    config.dlpLocation = "";
+    MockFailureCollector collector = new MockFailureCollector("DlpLocation");
+    config.validate(collector, null);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals("dlpLocation",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("Resource Location is not specified.",
+                        collector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testNullDlpLocation() {
+    DLPTransformPluginConfig config = new DLPTransformPluginConfig();
+    config.customTemplateEnabled = false;
+    MockFailureCollector collector = new MockFailureCollector("DlpLocation");
+    config.validate(collector, null);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals("dlpLocation",
+                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
+    Assert.assertEquals("Resource Location is not specified.",
+                        collector.getValidationFailures().get(0).getMessage());
   }
 }

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -159,30 +159,24 @@ public class UtilsTest {
   }
 
   @Test
-  public void testDlpLocation() throws NoSuchFieldException, IllegalAccessException {
+  public void testLocation() {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    String project = "test_project";
-    String location = "europe-west1";
-    Assert.assertEquals("projects/test_project/locations/europe-west1",
-      config.getLocationNameUtil(project, location).toString());
+    config.location = "europe-west1";
+    Assert.assertEquals("europe-west1", config.getLocation());
   }
 
   @Test
-  public void testEmptyDlpLocation() {
+  public void testEmptyLocation() {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    String project = "test_project";
-    String location = "";
-    Assert.assertEquals("projects/test_project/locations/global",
-      config.getLocationNameUtil(project, location).toString());
+    config.location = "";
+    Assert.assertEquals("global", config.getLocation());
   }
 
   @Test
-  public void testNullDlpLocation() {
+  public void testNullLocation() {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
-    String project = "test_project";
-    String location = null;
-    Assert.assertEquals("projects/test_project/locations/global",
-      config.getLocationNameUtil(project, location).toString());
+    config.location = null;
+    Assert.assertEquals("global", config.getLocation());
   }
 
   @Test
@@ -190,36 +184,36 @@ public class UtilsTest {
     Assume.assumeFalse(String.format(messageTemplate, "DLP Service Client"), serviceAccountFilePath == null);
     String text = "His name was Robert Frost";
     ByteContentItem byteContentItem =
-        ByteContentItem.newBuilder()
-            .setType(ByteContentItem.BytesType.TEXT_UTF8)
-            .setData(ByteString.copyFromUtf8(text))
-            .build();
+      ByteContentItem.newBuilder()
+        .setType(ByteContentItem.BytesType.TEXT_UTF8)
+        .setData(ByteString.copyFromUtf8(text))
+        .build();
     ContentItem contentItem = ContentItem.newBuilder().setByteItem(byteContentItem).build();
 
     List<InfoType> infoTypes =
-        Stream.of("PERSON_NAME", "US_STATE")
-            .map(it -> InfoType.newBuilder().setName(it).build())
-            .collect(Collectors.toList());
+      Stream.of("PERSON_NAME", "US_STATE")
+        .map(it -> InfoType.newBuilder().setName(it).build())
+        .collect(Collectors.toList());
 
     Likelihood minLikelihood = Likelihood.POSSIBLE;
 
     InspectConfig.FindingLimits findingLimits =
-        InspectConfig.FindingLimits.newBuilder().setMaxFindingsPerItem(0).build();
+      InspectConfig.FindingLimits.newBuilder().setMaxFindingsPerItem(0).build();
 
     InspectConfig inspectConfig =
-        InspectConfig.newBuilder()
-            .addAllInfoTypes(infoTypes)
-            .setMinLikelihood(minLikelihood)
-            .setLimits(findingLimits)
-            .setIncludeQuote(true)
-            .build();
+      InspectConfig.newBuilder()
+        .addAllInfoTypes(infoTypes)
+        .setMinLikelihood(minLikelihood)
+        .setLimits(findingLimits)
+        .setIncludeQuote(true)
+        .build();
 
     InspectContentRequest request =
-        InspectContentRequest.newBuilder()
-            .setParent(LocationName.of(projectId, "global").toString())
-            .setInspectConfig(inspectConfig)
-            .setItem(contentItem)
-            .build();
+      InspectContentRequest.newBuilder()
+        .setParent(LocationName.of(projectId, "global").toString())
+        .setInspectConfig(inspectConfig)
+        .setItem(contentItem)
+        .build();
 
     InspectContentResponse response = dlpServiceClient.inspectContent(request);
 

--- a/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
+++ b/src/test/java/io/cdap/plugin/dlp/UtilsTest.java
@@ -73,7 +73,6 @@ public class UtilsTest {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = true;
     config.templateId = null;
-    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("customTemplateEnabledAndEmpty");
     config.validate(collector, null);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -90,7 +89,6 @@ public class UtilsTest {
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = true;
     config.customTemplatePath = "simple_template";
-    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("customTemplateEnabled");
     config.validate(collector, null);
     Assert.assertEquals(0, collector.getValidationFailures().size());
@@ -102,7 +100,6 @@ public class UtilsTest {
     config.customTemplateEnabled = true;
     config.templateId = "template";
     config.customTemplatePath = "anotherTemplate";
-    config.dlpLocation = "global";
     MockFailureCollector collector = new MockFailureCollector("BothCustomTemplateEnabled");
     config.validate(collector, null);
     Assert.assertEquals(1, collector.getValidationFailures().size());
@@ -116,29 +113,31 @@ public class UtilsTest {
   }
 
   @Test
-  public void testEmptyDlpLocation() {
+  public void testDlpLocation() {
+    //DLPTransformPluginConfig is initialized with 'null' projectId
+    //if this logic is changed, this test case is going to fail
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = false;
-    config.dlpLocation = "";
-    MockFailureCollector collector = new MockFailureCollector("DlpLocation");
-    config.validate(collector, null);
-    Assert.assertEquals(1, collector.getValidationFailures().size());
-    Assert.assertEquals("dlpLocation",
-                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
-    Assert.assertEquals("Resource Location is not specified.",
-                        collector.getValidationFailures().get(0).getMessage());
+    config.dlpLocation = "europe-west1";
+    Assert.assertEquals("projects/null/locations/europe-west1", config.getDlpParentResourceLocation());
   }
 
   @Test
   public void testNullDlpLocation() {
+    //DLPTransformPluginConfig is initialized with 'null' projectId
+    //if this logic is changed, this test case is going to fail
     DLPTransformPluginConfig config = new DLPTransformPluginConfig();
     config.customTemplateEnabled = false;
-    MockFailureCollector collector = new MockFailureCollector("DlpLocation");
-    config.validate(collector, null);
-    Assert.assertEquals(1, collector.getValidationFailures().size());
-    Assert.assertEquals("dlpLocation",
-                        collector.getValidationFailures().get(0).getCauses().get(0).getAttribute("stageConfig"));
-    Assert.assertEquals("Resource Location is not specified.",
-                        collector.getValidationFailures().get(0).getMessage());
+    Assert.assertEquals("projects/null", config.getDlpParentResourceLocation());
+  }
+
+  @Test
+  public void testEmptyDlpLocation() {
+    //DLPTransformPluginConfig is initialized with 'null' projectId
+    //if this logic is changed, this test case is going to fail
+    DLPTransformPluginConfig config = new DLPTransformPluginConfig();
+    config.customTemplateEnabled = false;
+    config.dlpLocation = "";
+    Assert.assertEquals("projects/null", config.getDlpParentResourceLocation());
   }
 }

--- a/widgets/SensitiveRecordDecrypt-transform.json
+++ b/widgets/SensitiveRecordDecrypt-transform.json
@@ -46,7 +46,7 @@
       "properties": [
         {
           "widget-type": "text",
-          "name": "dlpLocation",
+          "name": "location",
           "label": "Resource Location",
           "widget-attributes": {
             "default": "global"

--- a/widgets/SensitiveRecordDecrypt-transform.json
+++ b/widgets/SensitiveRecordDecrypt-transform.json
@@ -42,6 +42,19 @@
       ]
     },
     {
+      "label": "Location",
+      "properties": [
+        {
+          "widget-type": "text",
+          "name": "dlpLocation",
+          "label": "Resource Location",
+          "widget-attributes": {
+            "default": "global"
+          }
+        }
+      ]
+    },
+    {
       "label": "Decrypt",
       "properties": [
         {

--- a/widgets/SensitiveRecordRedaction-transform.json
+++ b/widgets/SensitiveRecordRedaction-transform.json
@@ -42,6 +42,19 @@
       ]
     },
     {
+      "label": "Location",
+      "properties": [
+        {
+          "widget-type": "text",
+          "name": "dlpLocation",
+          "label": "Resource Location",
+          "widget-attributes": {
+            "default": "global"
+          }
+        }
+      ]
+    },
+    {
       "label": "Matching",
       "properties": [
         {

--- a/widgets/SensitiveRecordRedaction-transform.json
+++ b/widgets/SensitiveRecordRedaction-transform.json
@@ -46,7 +46,7 @@
       "properties": [
         {
           "widget-type": "text",
-          "name": "dlpLocation",
+          "name": "location",
           "label": "Resource Location",
           "widget-attributes": {
             "default": "global"


### PR DESCRIPTION
Added support to specify resource location for DLP service
Added validation to check if DLP location and CMEK location are same
Added test case which tests connection to DLP
Updated google-cloud-dlp version to 3.1.4
Added following maven dependencies (all of these are transitive dependencies from google-cloud-dlp, whose scope changed from compile to runtime in the latest version of google-cloud-dlp)
- gson - 2.9.0
- google-auth-library-oauth2-http - 1.5.3
- google-cloud-core - 2.5.6
- grpc-netty-shaded - 1.44.1
- opencensus-api - 0.31.0
- grpc-auth - 1.44.1
- perfmark-api - 0.23.0