### PR TITLE
Specify no context for deterministic encryption

### DIFF
--- a/widgets/SensitiveRecordRedaction-transform.json
+++ b/widgets/SensitiveRecordRedaction-transform.json
@@ -488,7 +488,7 @@
                       "allowedTypes": [
                         "string"
                       ],
-                      "description": "(Optional) Provide additional field to be used as Context. If the primary value is the same but the Context field value is different then two different encrypted values will be generated."
+                      "description": "(Optional) Provide additional field to be used as Context. If the primary value is the same but the Context field value is different then two different encrypted values will be generated. For deterministic encryption, do not specifiy a context."
                     }
                   }
                 ],
@@ -639,7 +639,7 @@
                       "allowedTypes": [
                         "string"
                       ],
-                      "description": "(Optional) Provide additional field to be used as Context. If the primary value is the same but the Context field value is different then two different encrypted values will be generated."
+                      "description": "(Optional) Provide additional field to be used as Context. If the primary value is the same but the Context field value is different then two different encrypted values will be generated. For deterministic encryption, do not specifiy a context."
                     }
                   }
                 ],


### PR DESCRIPTION
For deterministic encryption, do not specifiy a context to avoid the following error:

Re-identification failed either due to invalid context or corrupt deidentified value. Context must be equal to the value provided during de-identification.